### PR TITLE
names dev default solr core names based on the file that defines it

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -5,4 +5,4 @@ instance_dir: tmp/solr-development
 collection:
   persist: true
   dir: solr/conf/
-  name: hydra-development
+  name: nurax-pg-solrwrapper-dev

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,9 +1,9 @@
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/nurax-pg-blacklight-dev" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/nurax-pg-test" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/nurax-pg" %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -7,7 +7,7 @@ Hyrax.config do |config|
   # Injected via `rails g hyrax:work_resource GenericWork`
   config.register_curation_concern :generic_work
 
-  # config.disable_wings = true
+  # config.disable_wings = true # not needed if ENV includes HYRAX_SKIP_WINGS=true
 
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
-test:
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/nurax-pg-solr-dev" %>
+test: &test
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/nurax-pg-test" %>
 production:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/nurax-pg" %>

--- a/config/valkyrie_index.yml
+++ b/config/valkyrie_index.yml
@@ -1,11 +1,11 @@
 development:
   host: <%= ENV['VALKYRIE_SOLR_HOST'] || 'localhost' %>
   port: <%= ENV['VALKYRIE_SOLR_PORT'] || 8987 %>
-  core: <%= ENV['VALKYRIE_SOLR_CORE'] || 'hyrax-valkyrie-dev' %>
+  core: <%= ENV['VALKYRIE_SOLR_CORE'] || 'nurax-pg-valkyrie-dev' %>
 test:
   host: <%= ENV['VALKYRIE_SOLR_HOST'] || 'localhost' %>
   port: <%= ENV['VALKYRIE_SOLR_PORT'] || 8987 %>
-  core: <%= ENV['VALKYRIE_SOLR_CORE'] || 'hyrax-valkyrie-test' %>
+  core: <%= ENV['VALKYRIE_SOLR_CORE'] || 'nurax-pg-test' %>
 production:
   host: <%= ENV['VALKYRIE_SOLR_HOST'] %>
   port: <%= ENV['VALKYRIE_SOLR_PORT'] %>


### PR DESCRIPTION
This helps in debugging issues with solr.  It also makes sure the default for production is a core named `nurax-pg`.