### PR TITLE
fix dashboard failure caused by AF solr path not configured

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -327,3 +327,5 @@ custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
 custom_queries.each do |handler|
   Hyrax.query_service.custom_queries.register_query_handler(handler)
 end
+
+ActiveFedora.init(solr_config_path: Rails.root.join('config','solr.yml'))


### PR DESCRIPTION
Ideally we wouldn’t use AF SolrService at all, but for now its is ok.