### PR TITLE
reinstate roles in role_map.yml

### DIFF
--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -19,3 +19,30 @@
 #
 # You can create non-admin roles and assign users to those roles using a similar pattern.
 #
+# The following roles might be used for testing, so they remain here.  They will not
+# be available for use when logged in through the browser.
+#
+development:
+  archivist:
+    - archivist1@example.com
+
+test:
+  archivist:
+    - archivist1@example.com
+    - archivist2@example.com
+    - leland_himself@example.com
+  admin_policy_object_editor:
+    - archivist1@example.com
+  donor:
+    - donor1@example.com
+    - leland_himself@example.com
+  researcher:
+    - archivist1@example.com
+    - researcher1@example.com
+  patron:
+    - patron1@example.com
+    - leland_himself@example.com
+
+production:
+  admin:
+    - systems@curationexperts.com


### PR DESCRIPTION
Creating a work falls over if this file does not include role definitions.

```
web_1         | Completed 500 Internal Server Error in 846ms (ActiveRecord: 12.4ms)
web_1         |
web_1         |
web_1         |
web_1         | ActionView::Template::Error (config/role_map.yml was found, but was blank or malformed.
web_1         | ):
web_1         |     18:   </legend>
web_1         |     19:   <div class="col-sm-9 form-inline">
web_1         |     20:     <label for="new_group_name_skel" class="sr-only"><%= t(".group") %></label>
web_1         |     21:     <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + available_user_groups(ability: current_ability)), class: 'form-control' %>
web_1         |     22:     <label for="new_group_permission_skel" class="sr-only"><%= t(".access_type_to_grant") %></label>
web_1         |     23:     <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
web_1         |     24:
web_1         |
web_1         | hydra-access-controls (11.0.7) lib/hydra/role_mapper_behavior.rb:75:in `load_role_map'
web_1         | hydra-access-controls (11.0.7) lib/hydra/role_mapper_behavior.rb:33:in `map'
web_1         | hydra-access-controls (11.0.7) lib/hydra/role_mapper_behavior.rb:7:in `role_names'
web_1         | /usr/local/bundle/bundler/gems/hyrax-77f73f3faf1c/app/helpers/hyrax/hyrax_helper_behavior.rb:26:in `available_user_groups'
web_1         | /usr/local/bundle/bundler/gems/hyrax-77f73f3faf1c/app/views/hyrax/base/_form_share.html.erb:21:in `__usr_local_bundle_bundler_gems_hyrax___f__f_faf_c_app_views_hyrax_base__form_share_html_erb__3422479296656769522_480620'
```