### PR TITLE
Set ENV that backs Hyrax.config.use_valkyrie?

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ HUB_URL=http://chrome:4444/wd/hub
 HYRAX_DERIVATIVES_PATH=/app/samvera/hyrax-webapp/derivatives/
 HYRAX_ENGINE_PATH=/app/samvera/hyrax-engine
 HYRAX_UPLOAD_PATH=/app/samvera/hyrax-webapp/uploads/
+HYRAX_VALKYRIE=true
 IN_DOCKER=true
 METADATA_DATABASE_NAME=nurax_metadata_development
 MINIO_ENDPOINT=minio


### PR DESCRIPTION
Without this set `Hyrax.config.use_valkyrie?` returns false in the docker environment.